### PR TITLE
Dome Azimuth improvements

### DIFF
--- a/domehunter/dome_control.py
+++ b/domehunter/dome_control.py
@@ -296,8 +296,6 @@ class Dome(object):
 
         """
         if self.dome_az is None:
-            print("Dome Azimuth unknown, please manually trigger, \
-                  calibration from TheSkyX.")
             return
 
         target_az = Longitude(az * u.deg)

--- a/domehunter/dome_control.py
+++ b/domehunter/dome_control.py
@@ -247,9 +247,7 @@ class Dome(object):
     def dome_az(self):
         """ """
         if self._dome_az is None:
-            print("Cannot return Azimuth as Dome is not yet calibrated.\
-                   Run calibration loop")
-            return None
+            print("Cannot return Azimuth as Dome is not yet calibrated. Run calibration loop")
         return self._dome_az
 
     @property

--- a/domehunter/dome_control.py
+++ b/domehunter/dome_control.py
@@ -116,7 +116,7 @@ class Dome(object):
             The home azimuth position in degrees (integer between 0 and 360).
             Defaults to 0.
         az_position_tolerance: float
-            The tolerance, in units of degrees, used during GotoAz() calls.
+            The tolerance, in units of degrees, used during goto_az() calls.
             Dome will move to requested position to within this tolerance. If
             the calibrated degrees_per_tick is greater than
             az_position_tolerance, degrees_per_tick will be used as the
@@ -287,7 +287,7 @@ class Dome(object):
         # will receive no voltage even if the relay is in the open position?
         self._stop_moving()
 
-    def GotoAz(self, az):
+    def goto_az(self, az):
         """
         Send Dome to a requested Azimuth position.
 

--- a/domehunter/dome_control.py
+++ b/domehunter/dome_control.py
@@ -312,8 +312,8 @@ class Dome(object):
             self._rotate_dome(Direction.CCW)
         # wait until encoder count matches desired delta az
         while True:
-            distance_to_target = self.current_direction * (target_az - self.dome_az).wrap_at('180d')
-            if distance_to_target <= self.az_position_tolerance:
+            delta_az = self.current_direction * (target_az - self.dome_az).wrap_at('180d')
+            if delta_az <= self.az_position_tolerance:
                 break
             if self.testing:
                 # if testing simulate a tick for every cycle of while loop

--- a/domehunter/gRPC-server/hx2dome.proto_server.py
+++ b/domehunter/gRPC-server/hx2dome.proto_server.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import sys
 import time
 from concurrent import futures
 
@@ -88,7 +87,7 @@ class HX2DomeServer(hx2dome_pb2_grpc.HX2DomeServicer):
         else:
             return_code = 0
             try:
-                dome_az = self.dome.getAz()
+                dome_az = self.dome.dome_az
             except Exception:
                 # TODO: proper exception handling
                 dome_az = None

--- a/domehunter/tests/test_domehunter.py
+++ b/domehunter/tests/test_domehunter.py
@@ -27,7 +27,7 @@ def test_dome_initialisation(testing_dome):
     assert testing_dome.degrees_per_tick == Angle(1 * u.deg)
     assert testing_dome.at_home is False
     assert testing_dome.current_direction.name == "CCW"
-    assert bool(testing_dome.current_direction.value+1) is False
+    assert bool(testing_dome.current_direction.value + 1) is False
 
 
 def test_at_home(testing_dome):
@@ -52,9 +52,9 @@ def test_abort(testing_dome):
     assert testing_dome.dome_in_motion is False
 
 
-def test_getAz(dome_az_90):
-    assert dome_az_90.getAz() == 90
-    assert dome_az_90.getAz() == dome_az_90.dome_az.degree
+def test_dome_az(dome_az_90):
+    assert dome_az_90.dome_az == 90
+    assert dome_az_90.dome_az == dome_az_90.dome_az.degree
 
 
 def test_GotoAz(dome_az_90):

--- a/examples/dome_control_example.ipynb
+++ b/examples/dome_control_example.ipynb
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "# check where the dome thinks it is\n",
-    "testdome.getAz()"
+    "testdome.dome_az"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "# we can now check if the dome ended up where we wanted.\n",
-    "print(f'Dome is currently at an azimuth of {testdome.getAz()}, with an encoder count of {testdome.encoder_count}')"
+    "print(f'Dome is currently at an azimuth of {testdome.dome_az}, with an encoder count of {testdome.encoder_count}')"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "outputs": [],
    "source": [
     "# we can now check if the dome ended up where we wanted.\n",
-    "print(f'Dome is currently at an azimuth of {testdome.getAz()}, with an encoder count of {testdome.encoder_count}')"
+    "print(f'Dome is currently at an azimuth of {testdome.dome_az}, with an encoder count of {testdome.encoder_count}')"
    ]
   },
   {


### PR DESCRIPTION
* `_dome_az` is set when encoder is incremented rather than re-calcualted each time it is requested.
* Renamed `GotoAz` to `goto_az`.
* Remove `getAz` (same as `dome_az` property).
* Minor related cleanups.

Note that this makes it so `goto_az` will not work until dome has been calibrated.